### PR TITLE
remove -y flag when calling soup

### DIFF
--- a/usr/sbin/so-elastic-features
+++ b/usr/sbin/so-elastic-features
@@ -58,6 +58,6 @@ fi
 echo "Please wait while switching to Elastic Features."
 
 sed -i 's|^DOCKERHUB="securityonionsolutions|DOCKERHUB="securityonionsolutionselas|g' $ELASTICDOWNLOAD
-soup -y
+soup
 
 header "Once containers have started, you should have access to Elastic Features."


### PR DESCRIPTION
Never.  Ever.  Ever.  Ever cause a system to reboot without explicit consent from the administrator!  Ever!  That is very unfriendly behavior.

By calling soup with the -y flag here, it will not prompt before rebooting; the system will just disconnect.  If the state of the system is not such that it will survive a reboot, you've just caused an administrative headache.